### PR TITLE
Update QAicRuntimeTypes.h

### DIFF
--- a/inc/qaic-openrt-api-hpp/qaic-api-common/QAicRuntimeTypes.h
+++ b/inc/qaic-openrt-api-hpp/qaic-api-common/QAicRuntimeTypes.h
@@ -15,6 +15,7 @@
 #include "QAicTypes.h"
 #include <cstdint>
 #include <climits>
+#include <string>
 
 using QID = int32_t;
 using QCtrlChannelID = uint8_t;


### PR DESCRIPTION
This include is needed to avoid compilation error with gcc-11