### PR TITLE
Update thirdparty-modules/CMakeLists.txt and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Arch: x86 Ubuntu:  Centos:
 ### Prerequisites
 
   Build Dependencies
-    - CMake 3.24 or higher
-      Follow the instructions in [cmake](https://cmake.org/download/) for installation
+
+  - CMake 3.24 or higher:
+    Follow the instructions from [kitware](https://apt.kitware.com/) for installing on Ubuntu 22.04.
+  - Install necessary packages:
+    ```sudo apt update && sudo apt install build-essentials libudev-dev libpci-dev```
 
   Executable binary for QAic 100 Card
      - To generate a executable ML workload runnnable on QAic 100, please follow the instructions at [qualcomm-cloud-ai-100-cc](https://github.com/quic/software-kit-for-qualcomm-cloud-ai-100-cc)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,7 @@ fi
 
 
 pushd build
-cmakerc=`cmake ..`
+cmakerc=`cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..`
 if [ $cmakerc -ne 0 ] 2>/dev/null; then
 	echo "Cmake failed, exiting"
 	exit $cmakerc

--- a/thirdparty-modules/CMakeLists.txt
+++ b/thirdparty-modules/CMakeLists.txt
@@ -120,8 +120,9 @@ target_include_directories(module-qpcpp PUBLIC
 #Get gtest
 FetchContent_Declare(googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.10.0
+  GIT_TAG        release-1.12.0
   SOURCE_SUBDIR  googletest
   FIND_PACKAGE_ARGS NAMES googletest
 )
+set(GOOGLETEST_VERSION 1.12.0)
 FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
Update the googletest version in CMakeLists to fix compilation errors using modern GCC and modify the README to include updated cmake installation instructions and necessary packages.